### PR TITLE
Removed deprecated TSLint configuration options

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -37,7 +37,6 @@
     "curly": false,
     "forin": true,
     "label-position": true,
-    "label-undefined": true,
     "no-arg": true,
     "no-bitwise": true,
     "no-conditional-assignment": true,
@@ -69,11 +68,6 @@
       true,
       "allow-null-check"
     ],
-    "use-strict": [
-      true,
-      "check-module"
-    ],
-
     "eofline": true,
     "indent": [
       true,
@@ -103,7 +97,6 @@
     "interface-name": false,
     "jsdoc-format": true,
     "no-consecutive-blank-lines": false,
-    "no-constructor-vars": false,
     "one-line": [
       true,
       "check-open-brace",


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #1161


* **What is the current behavior?** (You can also link to an open issue here)
TSLint fails, breaking Karma tests.


* **What is the new behavior (if this is a feature change)?**
TSLint runs, allowing Karma tests to run.


* **Other information**:
Deprecated configuration options were breaking Karma tests
Would not be necessary if pull request #1105 is approved.
